### PR TITLE
fix(markets): allow owner role on polygon-markets routes

### DIFF
--- a/__tests__/integration/api/admin/polygon-markets-create.test.ts
+++ b/__tests__/integration/api/admin/polygon-markets-create.test.ts
@@ -32,6 +32,14 @@ describe('POST /api/admin/polygon-markets/create', () => {
     },
   };
 
+  const mockOwnerSession = {
+    user: {
+      id: 'owner-789',
+      email: 'owner@test.com',
+      role: 'owner',
+    },
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
   });
@@ -65,6 +73,20 @@ describe('POST /api/admin/polygon-markets/create', () => {
 
       expect(response.status).toBe(403);
       expect(data.error).toContain('Admin');
+    });
+
+    it('should accept owner role (passes authz, fails at validation)', async () => {
+      (getServerSession as jest.Mock).mockResolvedValue(mockOwnerSession);
+
+      const req = new NextRequest('http://localhost:3000/api/admin/polygon-markets/create', {
+        method: 'POST',
+        body: JSON.stringify({}),
+      });
+
+      const response = await POST(req);
+      // Owner is authorized — the request progresses past authz and hits
+      // body validation, which rejects with 400 because the body is empty.
+      expect(response.status).toBe(400);
     });
   });
 

--- a/src/app/api/admin/polygon-markets/[marketId]/route.ts
+++ b/src/app/api/admin/polygon-markets/[marketId]/route.ts
@@ -26,7 +26,7 @@ export async function PATCH(
     if (!session || !session.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    if (session.user.role !== 'admin') {
+    if (session.user.role !== 'admin' && session.user.role !== 'owner') {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 

--- a/src/app/api/admin/polygon-markets/create/route.ts
+++ b/src/app/api/admin/polygon-markets/create/route.ts
@@ -35,8 +35,8 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 2. Authorization check (admin only)
-    if (session.user.role !== 'admin') {
+    // 2. Authorization check (admin or owner)
+    if (session.user.role !== 'admin' && session.user.role !== 'owner') {
       return NextResponse.json(
         { error: 'Forbidden - Admin access required' },
         { status: 403 }

--- a/src/app/api/admin/polygon-markets/route.ts
+++ b/src/app/api/admin/polygon-markets/route.ts
@@ -13,7 +13,7 @@ export async function GET() {
     if (!session || !session.user) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
-    if (session.user.role !== 'admin') {
+    if (session.user.role !== 'admin' && session.user.role !== 'owner') {
       return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
     }
 


### PR DESCRIPTION
## Summary

`/dashboard/markets` shows **Forbidden** for the project owner because the 3 polygon-markets API routes strictly check `role !== 'admin'`, which excludes `owner`. Stats render as zeros because they're computed client-side from the empty markets array after the API rejects the fetch.

## Root cause

The check is at:
- `src/app/api/admin/polygon-markets/route.ts:16`
- `src/app/api/admin/polygon-markets/create/route.ts:39`
- `src/app/api/admin/polygon-markets/[marketId]/route.ts:29`

All three say `if (session.user.role !== 'admin')`. Owner sessions hit the 403 branch and get `{ error: 'Forbidden' }`.

The rest of the admin app uses `requireAuth(['owner','admin'])` from `src/app/lib/authMiddleware.ts` (waitlist, agents) — owner is the established management tier alongside admin.

## Fix

Broaden the role check to `role !== 'admin' && role !== 'owner'`. Minimal diff (one extra clause per route).

## Tests

- Existing rejection test (`role: 'user'`) still passes — non-admin users still get 403.
- New `should accept owner role` test on the create route asserts authz now lets owner through (request progresses past authz to body validation, returning 400 on the empty body — proves the gate is no longer the rejection point).
- 11/11 polygon-markets-create tests pass.

## Out of scope

- `src/app/api/leaderboard/refresh/route.ts:23` has the same strict-admin check but is cron-protected (cron OR admin). Not user-visible from `/dashboard/markets`. Separate concern.
- Whether `moderator` should also access markets — keeping current intent (admin/owner only).

## Test plan

- [ ] Visit `/dashboard/markets` as owner — list loads, stats reflect data.
- [ ] Create market as owner — succeeds.
- [ ] PATCH market as owner — succeeds.
- [ ] As `user` role, all three return 403 (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
